### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 precinct-shapefiles
 ===================
 
-##Voting Precinct Shapefiles in the United States
+## Voting Precinct Shapefiles in the United States
 
 **Update Mar 2017**: A better, more up-to-date repository of shapefiles is [here](https://github.com/nvkelso/election-geodata)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
